### PR TITLE
Add magic to install pyodide-http

### DIFF
--- a/notebooks/cross_validation_baseline.ipynb
+++ b/notebooks/cross_validation_baseline.ipynb
@@ -32,7 +32,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/cross_validation_learning_curve.ipynb
+++ b/notebooks/cross_validation_learning_curve.ipynb
@@ -24,7 +24,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "housing = fetch_california_housing(as_frame=True)\n",
     "data, target = housing.data, housing.target\n",

--- a/notebooks/cross_validation_train_test.ipynb
+++ b/notebooks/cross_validation_train_test.ipynb
@@ -24,7 +24,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "housing = fetch_california_housing(as_frame=True)\n",
     "data, target = housing.data, housing.target"

--- a/notebooks/cross_validation_validation_curve.ipynb
+++ b/notebooks/cross_validation_validation_curve.ipynb
@@ -23,7 +23,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "housing = fetch_california_housing(as_frame=True)\n",
     "data, target = housing.data, housing.target\n",

--- a/notebooks/datasets_california_housing.ipynb
+++ b/notebooks/datasets_california_housing.ipynb
@@ -17,7 +17,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "california_housing = fetch_california_housing(as_frame=True)"
    ]

--- a/notebooks/dev_features_importance.ipynb
+++ b/notebooks/dev_features_importance.ipynb
@@ -38,8 +38,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets import fetch_california_housing\n",
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "import pandas as pd\n",
+    "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "X, y = fetch_california_housing(as_frame=True, return_X_y=True)"
    ]

--- a/notebooks/ensemble_ex_01.ipynb
+++ b/notebooks/ensemble_ex_01.ipynb
@@ -19,8 +19,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(as_frame=True, return_X_y=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/ensemble_ex_03.ipynb
+++ b/notebooks/ensemble_ex_03.ipynb
@@ -22,8 +22,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/ensemble_ex_04.ipynb
+++ b/notebooks/ensemble_ex_04.ipynb
@@ -20,7 +20,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/ensemble_gradient_boosting.ipynb
+++ b/notebooks/ensemble_gradient_boosting.ipynb
@@ -389,8 +389,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import cross_validate\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/ensemble_hist_gradient_boosting.ipynb
+++ b/notebooks/ensemble_hist_gradient_boosting.ipynb
@@ -38,7 +38,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/ensemble_hyperparameters.ipynb
+++ b/notebooks/ensemble_hyperparameters.ipynb
@@ -26,8 +26,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/ensemble_introduction.ipynb
+++ b/notebooks/ensemble_introduction.ipynb
@@ -32,7 +32,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(as_frame=True, return_X_y=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/ensemble_sol_01.ipynb
+++ b/notebooks/ensemble_sol_01.ipynb
@@ -19,8 +19,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(as_frame=True, return_X_y=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/ensemble_sol_03.ipynb
+++ b/notebooks/ensemble_sol_03.ipynb
@@ -22,8 +22,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/ensemble_sol_04.ipynb
+++ b/notebooks/ensemble_sol_04.ipynb
@@ -20,7 +20,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$"

--- a/notebooks/parameter_tuning_ex_03.ipynb
+++ b/notebooks/parameter_tuning_ex_03.ipynb
@@ -16,8 +16,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/notebooks/parameter_tuning_sol_03.ipynb
+++ b/notebooks/parameter_tuning_sol_03.ipynb
@@ -16,8 +16,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pyodide-http\n",
+    "import pyodide_http\n",
     "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "pyodide_http.patch_all()\n",
     "\n",
     "data, target = fetch_california_housing(return_X_y=True, as_frame=True)\n",
     "target *= 100  # rescale the target in k$\n",

--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -23,7 +23,11 @@
 # ```
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/cross_validation_learning_curve.py
+++ b/python_scripts/cross_validation_learning_curve.py
@@ -20,7 +20,11 @@
 # notebook.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 housing = fetch_california_housing(as_frame=True)
 data, target = housing.data, housing.target

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -20,7 +20,11 @@
 # dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 housing = fetch_california_housing(as_frame=True)
 data, target = housing.data, housing.target

--- a/python_scripts/cross_validation_validation_curve.py
+++ b/python_scripts/cross_validation_validation_curve.py
@@ -19,7 +19,11 @@
 # notebook.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 housing = fetch_california_housing(as_frame=True)
 data, target = housing.data, housing.target

--- a/python_scripts/datasets_california_housing.py
+++ b/python_scripts/datasets_california_housing.py
@@ -13,7 +13,11 @@
 # scikit-learn.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 california_housing = fetch_california_housing(as_frame=True)
 

--- a/python_scripts/dev_features_importance.py
+++ b/python_scripts/dev_features_importance.py
@@ -26,8 +26,12 @@
 # the median income of people in the neighborhoods (block).
 
 # %%
-from sklearn.datasets import fetch_california_housing
+# %pip install pyodide-http
+import pyodide_http
 import pandas as pd
+from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -21,8 +21,12 @@
 # testing set.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(as_frame=True, return_X_y=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_ex_03.py
+++ b/python_scripts/ensemble_ex_03.py
@@ -24,8 +24,12 @@
 # We use the California housing dataset to conduct our experiments.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_ex_04.py
+++ b/python_scripts/ensemble_ex_04.py
@@ -22,7 +22,11 @@
 # We will use the California housing dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -266,8 +266,12 @@ print(f"Error of the tree: {target_true - y_pred_first_and_second_tree:.3f}")
 # boosting on the California housing dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import cross_validate
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_hist_gradient_boosting.py
+++ b/python_scripts/ensemble_hist_gradient_boosting.py
@@ -34,7 +34,11 @@
 # from scikit-learn. First, we will load the California housing dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_hyperparameters.py
+++ b/python_scripts/ensemble_hyperparameters.py
@@ -21,8 +21,12 @@
 # We start by loading the california housing dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_introduction.py
+++ b/python_scripts/ensemble_introduction.py
@@ -23,7 +23,11 @@
 # ```
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(as_frame=True, return_X_y=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_sol_01.py
+++ b/python_scripts/ensemble_sol_01.py
@@ -15,8 +15,12 @@
 # testing set.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(as_frame=True, return_X_y=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_sol_03.py
+++ b/python_scripts/ensemble_sol_03.py
@@ -18,8 +18,12 @@
 # We use the California housing dataset to conduct our experiments.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/ensemble_sol_04.py
+++ b/python_scripts/ensemble_sol_04.py
@@ -16,7 +16,11 @@
 # We will use the California housing dataset.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -18,8 +18,12 @@
 # generalization performance on a training set.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$

--- a/python_scripts/parameter_tuning_sol_03.py
+++ b/python_scripts/parameter_tuning_sol_03.py
@@ -12,8 +12,12 @@
 # generalization performance on a training set.
 
 # %%
+# %pip install pyodide-http
+import pyodide_http
 from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
+
+pyodide_http.patch_all()
 
 data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$


### PR DESCRIPTION
In #6 I introduced the installations for seaborn and plotly, but forgot the required `pyodide-http` installation to use along `sklearn.dataset.fetch_*` fetching utilities.

This PR addresses the issue.