### PR TITLE
Add imports to matplotlib and other fixes

### DIFF
--- a/notebooks/01_tabular_data_exploration.ipynb
+++ b/notebooks/01_tabular_data_exploration.ipynb
@@ -261,6 +261,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib  # required to use pandas plotting in jupyterlite\n",
+    "\n",
     "_ = adult_census.hist(figsize=(20, 14))"
    ]
   },
@@ -406,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install seaborn\n",
+    "%pip install seaborn  # required to use seaborn in jupyterlite\n",
     "import seaborn as sns\n",
     "\n",
     "# We plot a subset of the data to keep the plot readable and make the plotting\n",

--- a/notebooks/01_tabular_data_exploration_ex_01.ipynb
+++ b/notebooks/01_tabular_data_exploration_ex_01.ipynb
@@ -85,6 +85,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib\n",
+    "\n",
     "# Write your code here."
    ]
   },

--- a/notebooks/01_tabular_data_exploration_sol_01.ipynb
+++ b/notebooks/01_tabular_data_exploration_sol_01.ipynb
@@ -114,6 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib\n",
+    "\n",
     "# solution\n",
     "_ = penguins.hist(figsize=(8, 4))"
    ]

--- a/notebooks/datasets_blood_transfusion.ipynb
+++ b/notebooks/datasets_blood_transfusion.ipynb
@@ -116,6 +116,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib\n",
+    "\n",
     "_ = data.hist(figsize=(12, 10), bins=30, edgecolor=\"black\")"
    ]
   },

--- a/notebooks/overfit_wrap_up_ex_00.ipynb
+++ b/notebooks/overfit_wrap_up_ex_00.ipynb
@@ -193,7 +193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Set `n_neighbors=1` in the previous model and evaluate it using a 10-fold\n",
+    "Set `n_neighbors=1` in the previous model and evaluate it using a 10-fold\n",
     "cross-validation. Use the balanced accuracy as a score. What can you say about\n",
     "this model? Compare the average of the train and test scores to argument your\n",
     "answer.\n",
@@ -279,18 +279,16 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Select the most correct of the affirmations stated below:\n",
-    "#\n",
-    "# - a) The model best generalizes for a range of `n_neighbors` values between 1 to 10\n",
-    "# - b) The model best generalizes for a range of `n_neighbors` values between 10 to 100\n",
-    "# - c) The model best generalizes for a range of `n_neighbors` values between 100 to 500\n",
-    "#\n",
-    "# _Select a single answer_"
+    "Select the most correct of the affirmations stated below:\n",
+    "\n",
+    "- a) The model best generalizes for a range of `n_neighbors` values between 1 to 10\n",
+    "- b) The model best generalizes for a range of `n_neighbors` values between 10 to 100\n",
+    "- c) The model best generalizes for a range of `n_neighbors` values between 100 to 500\n",
+    "\n",
+    "_Select a single answer_"
    ]
   }
  ],

--- a/python_scripts/01_tabular_data_exploration.py
+++ b/python_scripts/01_tabular_data_exploration.py
@@ -166,6 +166,8 @@ print(f"The dataset contains {adult_census.shape[1] - 1} features.")
 # for features containing numerical values:
 
 # %%
+import matplotlib  # required to use pandas plotting in jupyterlite
+
 _ = adult_census.hist(figsize=(20, 14))
 
 # %% [markdown]
@@ -254,7 +256,7 @@ pd.crosstab(
 # variables.
 
 # %%
-# %pip install seaborn
+# %pip install seaborn  # required to use seaborn in jupyterlite
 import seaborn as sns
 
 # We plot a subset of the data to keep the plot readable and make the plotting

--- a/python_scripts/01_tabular_data_exploration_ex_01.py
+++ b/python_scripts/01_tabular_data_exploration_ex_01.py
@@ -49,6 +49,8 @@
 # Plot histograms for the numerical features
 
 # %%
+import matplotlib
+
 # Write your code here.
 
 # %% [markdown]

--- a/python_scripts/01_tabular_data_exploration_sol_01.py
+++ b/python_scripts/01_tabular_data_exploration_sol_01.py
@@ -56,6 +56,8 @@ penguins["Species"].value_counts()
 # Plot histograms for the numerical features
 
 # %%
+import matplotlib
+
 # solution
 _ = penguins.hist(figsize=(8, 4))
 

--- a/python_scripts/datasets_blood_transfusion.py
+++ b/python_scripts/datasets_blood_transfusion.py
@@ -62,6 +62,8 @@ data.info()
 # distributions.
 
 # %%
+import matplotlib
+
 _ = data.hist(figsize=(12, 10), bins=30, edgecolor="black")
 
 # %% [markdown]


### PR DESCRIPTION
In #6 and #7 I introduced installations necessary to use jupyterlite.
In this PR I introduce the import to matplotlib, required to use pandas plotting utilities.
I also took the opportunity to fix an unrelated format issue in the overfit_wrap_up_ex_00.