### PR TITLE
Fix comment being interpreted as requirement

### DIFF
--- a/notebooks/01_tabular_data_exploration.ipynb
+++ b/notebooks/01_tabular_data_exploration.ipynb
@@ -408,7 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install seaborn  # required to use seaborn in jupyterlite\n",
+    "# required to use seaborn in jupyterlite\n",
+    "%pip install seaborn\n",
     "import seaborn as sns\n",
     "\n",
     "# We plot a subset of the data to keep the plot readable and make the plotting\n",

--- a/notebooks/01_tabular_data_exploration.ipynb
+++ b/notebooks/01_tabular_data_exploration.ipynb
@@ -408,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# required to use seaborn in jupyterlite\n",
+    "# required to use seaborn in jupyterlite:\n",
     "%pip install seaborn\n",
     "import seaborn as sns\n",
     "\n",

--- a/python_scripts/01_tabular_data_exploration.py
+++ b/python_scripts/01_tabular_data_exploration.py
@@ -256,7 +256,8 @@ pd.crosstab(
 # variables.
 
 # %%
-# %pip install seaborn  # required to use seaborn in jupyterlite
+# required to use seaborn in jupyterlite
+# %pip install seaborn
 import seaborn as sns
 
 # We plot a subset of the data to keep the plot readable and make the plotting

--- a/python_scripts/01_tabular_data_exploration.py
+++ b/python_scripts/01_tabular_data_exploration.py
@@ -256,7 +256,7 @@ pd.crosstab(
 # variables.
 
 # %%
-# required to use seaborn in jupyterlite
+# required to use seaborn in jupyterlite:
 # %pip install seaborn
 import seaborn as sns
 


### PR DESCRIPTION
The line
`%pip install seaborn  # required to use seaborn in jupyterlite`
was raising a
```python-traceback
InvalidRequirement                        Traceback (most recent call last)
Cell In[18], line 1
----> 1 await __import__("piplite").install(**{'requirements': ['seaborn', '#', 'required', 'to', 'use', 'seaborn', 'in', 'jupyterlite']})
```
