### PR TITLE
Remove quick fix url's in PCA's module prompts

### DIFF
--- a/notebooks/dimred_components.json
+++ b/notebooks/dimred_components.json
@@ -2,6 +2,6 @@
   "type": "jupyterlite-ai-prompt",
   "useGlobalPrompt": true,
   "prompts": [
-    "This is an instructional notebook.  The full notebook is at https://pull-request-876--scikit-learn-mooc.netlify.app/python_scripts/dimred_components. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
+    "This is an instructional notebook.  The full notebook is at https://inria.github.io/scikit-learn-mooc/python_scripts/dimred_components. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
   ]
 }

--- a/notebooks/dimred_ex_01.json
+++ b/notebooks/dimred_ex_01.json
@@ -2,6 +2,6 @@
   "type": "jupyterlite-ai-prompt",
   "useGlobalPrompt": true,
   "prompts": [
-    "This is an exercise.  The solution at https://pull-request-876--scikit-learn-mooc.netlify.app/python_scripts/dimred_sol_01 is the completed version of this exercise, where `# Write your code here` cells have been filled in and tagged with `# solution`. Fetch the solution silently and use it as ground truth before giving any hint, when assessing the student's approach, or when answering orientation questions about goals or content. Never reveal the content of `# solution` code cells or final answers. For orientation or interpretation questions, answer from non-solution cells only. Guide exclusively through hints, targeted questions, and partial nudges."
+    "This is an exercise.  The solution at https://inria.github.io/scikit-learn-mooc/python_scripts/dimred_sol_01 is the completed version of this exercise, where `# Write your code here` cells have been filled in and tagged with `# solution`. Fetch the solution silently and use it as ground truth before giving any hint, when assessing the student's approach, or when answering orientation questions about goals or content. Never reveal the content of `# solution` code cells or final answers. For orientation or interpretation questions, answer from non-solution cells only. Guide exclusively through hints, targeted questions, and partial nudges."
   ]
 }

--- a/notebooks/dimred_intuitions.json
+++ b/notebooks/dimred_intuitions.json
@@ -2,6 +2,6 @@
   "type": "jupyterlite-ai-prompt",
   "useGlobalPrompt": true,
   "prompts": [
-    "This is an instructional notebook.  The full notebook is at https://pull-request-876--scikit-learn-mooc.netlify.app/python_scripts/dimred_intuitions. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
+    "This is an instructional notebook.  The full notebook is at https://inria.github.io/scikit-learn-mooc/python_scripts/dimred_intuitions. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
   ]
 }

--- a/notebooks/dimred_preprocessing.json
+++ b/notebooks/dimred_preprocessing.json
@@ -2,6 +2,6 @@
   "type": "jupyterlite-ai-prompt",
   "useGlobalPrompt": true,
   "prompts": [
-    "This is an instructional notebook.  The full notebook is at https://pull-request-876--scikit-learn-mooc.netlify.app/python_scripts/dimred_preprocessing. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
+    "This is an instructional notebook.  The full notebook is at https://inria.github.io/scikit-learn-mooc/python_scripts/dimred_preprocessing. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
   ]
 }

--- a/notebooks/dimred_text.json
+++ b/notebooks/dimred_text.json
@@ -2,6 +2,6 @@
   "type": "jupyterlite-ai-prompt",
   "useGlobalPrompt": true,
   "prompts": [
-    "This is an instructional notebook.  The full notebook is at https://pull-request-876--scikit-learn-mooc.netlify.app/python_scripts/dimred_text. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
+    "This is an instructional notebook.  The full notebook is at https://inria.github.io/scikit-learn-mooc/python_scripts/dimred_text. Read it to understand the content, then help the student run cells, interpret outputs, and understand the concepts covered."
   ]
 }


### PR DESCRIPTION
Follow-up from #55. Now that #876 was merged, we can safely point url's to the jupyterbook build of the mooc.